### PR TITLE
Remove Typo3 v10 and v11 compatibility for composer installs

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -26,8 +26,8 @@
     "GPL-3.0-or-later"
   ],
   "require": {
-    "typo3/cms-core": "^10.4.0||^11.5.0||^12.4.7||dev-master",
-    "typo3/cms-rte-ckeditor": "^10.4.0||^11.5.0||^12.4.7||dev-master"
+    "typo3/cms-core": "^12.4.7||dev-master",
+    "typo3/cms-rte-ckeditor": "^12.4.7||dev-master"
   },
   "replace": {
     "typo3-ter/rte_ckeditor_fontawesome": "self.version"


### PR DESCRIPTION
It now matches ext_emconf.php's requirements

Fixes #47 